### PR TITLE
Remove `fetch-tags` from action

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -25,8 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
-          fetch-depth: 20
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
It seems that `fetch-tags` is buggy when triggering action on tag: https://github.com/actions/checkout/issues/1467